### PR TITLE
Allow use of another database name

### DIFF
--- a/prerun_hook.sh
+++ b/prerun_hook.sh
@@ -10,7 +10,7 @@ databases:
     connector: postgres
     host: ${DB_HOST}
     port: ${DB_PORT}
-    database: prisma
+    database: ${DB_NAME}
     schema: public
     user: ${DB_USER}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
To deploy with Heroku postgres you need to be able to set the database name that Heroku supplies.